### PR TITLE
Replace argument with 'it' in let block

### DIFF
--- a/app/src/main/kotlin/amhk/chronos/database/ChronosDatabase.kt
+++ b/app/src/main/kotlin/amhk/chronos/database/ChronosDatabase.kt
@@ -39,7 +39,7 @@ internal object Converters {
     @JvmStatic
     fun toOffsetDateTime(value: String?): OffsetDateTime? {
         return value?.let {
-            return formatter.parse(value, OffsetDateTime::from)
+            return formatter.parse(it, OffsetDateTime::from)
         }
     }
 


### PR DESCRIPTION
'let' takes 'this' as its argument so repeating 'value'
is redundant when passed to formatter's parse method
as non-null.

Signed-off-by: Zoran Jovanovic <zoran.jovanovic@sony.com>