### PR TITLE
Suppress unchecked cast to LiveData<Block>

### DIFF
--- a/app/src/main/kotlin/amhk/chronos/model/BlockDetailsViewModel.kt
+++ b/app/src/main/kotlin/amhk/chronos/model/BlockDetailsViewModel.kt
@@ -12,6 +12,7 @@ internal class BlockDetailsViewModel(app: Application) : AndroidViewModel(app) {
     fun getBlockById(id: Long): LiveData<Block> {
         var value = map[id]
         if (value == null) {
+            @Suppress("UNCHECKED_CAST")
             value = dao.selectById(id) as LiveData<Block>
             map[id] = value
         }


### PR DESCRIPTION
This cast is exactly what is wanted at this point,
a.k.a. "I know what I'm doing", that is Mårten
knew what he was doing here where a workaround to
create a copy of LiveData with items of correct type
would be an overkill.

Signed-off-by: Zoran Jovanovic <zoran.jovanovic@sony.com>