### PR TITLE
Remove redundant dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:1.1.0"
     implementation "androidx.core:core-ktx:${versions.androidx}"
     implementation "androidx.lifecycle:lifecycle-extensions:${versions.jetpack}"
-    implementation "androidx.lifecycle:lifecycle-livedata:${versions.jetpack}"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'


### PR DESCRIPTION
The lifecycle-livedata component is part of lifecycle-extensions. There
is no need to have it explicitly unless you don't need the ModelView
parts.

Change-Id: I7113c13d2e50dce0e0bceb3d6a74a35ecd620fcb